### PR TITLE
Make reqwest as optional

### DIFF
--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -13,7 +13,7 @@ google-cloud-derive = { version = "=0.1.0", path = "../google-cloud-derive", opt
 
 tonic = { version = "0.2.0", features = ["tls", "prost"] }
 tokio = { version = "0.2.18", features = ["macros", "fs"] }
-reqwest = { version = "0.10.4", features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.10.4", optional = true, features = ["blocking", "json", "rustls-tls"] }
 futures = "0.3.4"
 
 prost = "0.6.1"
@@ -41,5 +41,5 @@ pubsub = []
 datastore = []
 datastore-derive = ["datastore", "google-cloud-derive"]
 vision = []
-storage = []
+storage = ["reqwest"]
 derive = ["datastore-derive"]

--- a/google-cloud/src/error.rs
+++ b/google-cloud/src/error.rs
@@ -22,6 +22,7 @@ pub enum Error {
     #[error("environment error: {0}")]
     Env(#[from] env::VarError),
     /// Reqwest error (HTTP errors).
+    #[cfg(feature = "storage")]
     #[error("HTTP error: {0}")]
     Reqwest(#[from] reqwest::Error),
     /// conversion error (`try_from(..)` or `try_into(..)` errors).


### PR DESCRIPTION
Reduce the binary size and number of dependent libraries. Reqwest is only used by Storage, which may get a [gRPC API soon](https://github.com/googleapis/googleapis/blob/5340d28e386f4a70b6e9da146858b3f129b790a7/google/storage/v1/storage_v1.yaml).