### PR TITLE
Make reqwest as optional

### DIFF
--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -11,9 +11,11 @@ keywords = ["grpc", "futures", "async", "protobuf", "google", "cloud"]
 # Derive macros
 google-cloud-derive = { version = "=0.1.0", path = "../google-cloud-derive", optional = true }
 
-tonic = { version = "0.2.0", features = ["tls", "prost"] }
+tonic = { version = "0.3.0", features = ["tls", "prost"] }
 tokio = { version = "0.2.18", features = ["macros", "fs"] }
-reqwest = { version = "0.10.4", features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.10.4", optional = true, default_features = false, features = ["blocking", "json", "rustls-tls"] }
+hyper = { version = "0.13.7" }
+hyper-rustls = { version = "0.21.0" }
 futures = "0.3.4"
 
 prost = "0.6.1"
@@ -31,7 +33,7 @@ thiserror = "1.0.15"
 bytes = { version = "0.5.4", optional = true }
 
 [build-dependencies]
-tonic-build = "0.2.0"
+tonic-build = "0.3.0"
 
 [features]
 default = []
@@ -41,5 +43,5 @@ pubsub = []
 datastore = []
 datastore-derive = ["datastore", "google-cloud-derive"]
 vision = []
-storage = []
+storage = ["reqwest"]
 derive = ["datastore-derive"]

--- a/google-cloud/src/authorize/mod.rs
+++ b/google-cloud/src/authorize/mod.rs
@@ -2,8 +2,9 @@ use std::fmt;
 
 use chrono::offset::Utc;
 use chrono::DateTime;
+use hyper::client::{Client, HttpConnector};
+use hyper_rustls::HttpsConnector;
 use json::json;
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AuthError;
@@ -51,7 +52,7 @@ pub(crate) struct Token {
 
 #[derive(Debug, Clone)]
 pub(crate) struct TokenManager {
-    client: Client,
+    client: Client<HttpsConnector<HttpConnector>>,
     scopes: String,
     creds: ApplicationCredentials,
     current_token: Option<Token>,
@@ -66,7 +67,7 @@ impl TokenManager {
     pub(crate) fn new(creds: ApplicationCredentials, scopes: &[&str]) -> TokenManager {
         TokenManager {
             creds,
-            client: Client::new(),
+            client: Client::builder().build::<_, hyper::Body>(HttpsConnector::new()),
             scopes: scopes.join(" "),
             current_token: None,
         }
@@ -96,21 +97,24 @@ impl TokenManager {
                     &payload,
                     jwt::Algorithm::RS256,
                 )?;
-                let body = [
-                    ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
-                    ("assertion", token.as_str()),
-                ];
+                let form = format!(
+                    "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion={}",
+                    token.as_str()
+                );
 
-                let response: AuthResponse = self
-                    .client
-                    .post(AUTH_ENDPOINT)
-                    .form(&body)
-                    .send()
+                let req = hyper::Request::builder()
+                    .method("POST")
+                    .uri(AUTH_ENDPOINT)
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(hyper::Body::from(form))?;
+
+                let data = hyper::body::to_bytes(self.client.request(req).await?.into_body())
                     .await?
-                    .json()
-                    .await?;
+                    .to_vec();
 
-                let value = TokenValue::Bearer(response.access_token);
+                let ar: AuthResponse = json::from_slice(&data)?;
+
+                let value = TokenValue::Bearer(ar.access_token);
                 let token = value.to_string();
                 self.current_token = Some(Token { expiry, value });
 

--- a/google-cloud/src/datastore/client.rs
+++ b/google-cloud/src/datastore/client.rs
@@ -64,7 +64,7 @@ impl Client {
             .domain_name(Client::DOMAIN_NAME);
 
         let channel = Channel::from_static(Client::ENDPOINT)
-            .tls_config(tls_config)
+            .tls_config(tls_config)?
             .connect()
             .await?;
 

--- a/google-cloud/src/error.rs
+++ b/google-cloud/src/error.rs
@@ -22,6 +22,7 @@ pub enum Error {
     #[error("environment error: {0}")]
     Env(#[from] env::VarError),
     /// Reqwest error (HTTP errors).
+    #[cfg(feature = "storage")]
     #[error("HTTP error: {0}")]
     Reqwest(#[from] reqwest::Error),
     /// conversion error (`try_from(..)` or `try_into(..)` errors).
@@ -57,7 +58,10 @@ pub enum AuthError {
     /// A JSON (de)serialization error.
     #[error("JSON error: {0}")]
     JSON(#[from] json::Error),
-    /// Reqwest error (HTTP errors).
-    #[error("HTTP error: {0}")]
-    Reqwest(#[from] reqwest::Error),
+    /// HTTP errors
+    #[error("Hyper error: {0}")]
+    Http(#[from] http::Error),
+    /// Hyper errors
+    #[error("Hyper error: {0}")]
+    Hyper(#[from] hyper::Error),
 }

--- a/google-cloud/src/pubsub/client.rs
+++ b/google-cloud/src/pubsub/client.rs
@@ -61,7 +61,7 @@ impl Client {
             .domain_name(Client::DOMAIN_NAME);
 
         let channel = Channel::from_static(Client::ENDPOINT)
-            .tls_config(tls_config)
+            .tls_config(tls_config)?
             .connect()
             .await?;
 

--- a/google-cloud/src/vision/client.rs
+++ b/google-cloud/src/vision/client.rs
@@ -64,7 +64,7 @@ impl Client {
             .domain_name(Client::DOMAIN_NAME);
 
         let channel = Channel::from_static(Client::ENDPOINT)
-            .tls_config(tls_config)
+            .tls_config(tls_config)?
             .connect()
             .await?;
 


### PR DESCRIPTION
This patch makes Reqwest optional if feature storage is not enabled. Also set `default_features` to false to avoid pulling openssl.

This patch also bumps Tonic to 0.3.0, otherwise two versions of tokio-rustls and rustls will be included.