### PR TITLE
pubsub: Swap id and name for struct topic and subscription

### DIFF
--- a/google-cloud/src/pubsub/message.rs
+++ b/google-cloud/src/pubsub/message.rs
@@ -41,11 +41,7 @@ impl Message {
     /// If a message isn't acknowledged, it will be redelivered to other subscribers.
     pub async fn ack(&mut self) -> Result<(), Error> {
         let request = api::AcknowledgeRequest {
-            subscription: format!(
-                "projects/{0}/subscriptions/{1}",
-                self.client.project_name.as_str(),
-                self.subscription_name,
-            ),
+            subscription: self.subscription_name.clone(),
             ack_ids: vec![self.ack_id.clone()],
         };
         let request = self.client.construct_request(request).await?;
@@ -59,11 +55,7 @@ impl Message {
     /// This allows Pub/Sub to redeliver the message more quickly than by awaiting the acknowledgement timeout.
     pub async fn nack(&mut self) -> Result<(), Error> {
         let request = api::ModifyAckDeadlineRequest {
-            subscription: format!(
-                "projects/{0}/subscriptions/{1}",
-                self.client.project_name.as_str(),
-                self.subscription_name,
-            ),
+            subscription: self.subscription_name.clone(),
             ack_ids: vec![self.ack_id.clone()],
             ack_deadline_seconds: 0,
         };

--- a/google-cloud/src/pubsub/subscription.rs
+++ b/google-cloud/src/pubsub/subscription.rs
@@ -64,6 +64,11 @@ impl Subscription {
         }
     }
 
+    /// Returns the unique identifier within its project
+    pub fn id(&self) -> &str {
+        self.name.rsplit('/').next().unwrap()
+    }
+
     /// Receive the next message from the subscription.
     pub async fn receive(&mut self) -> Option<Message> {
         loop {
@@ -95,11 +100,7 @@ impl Subscription {
     /// Delete the subscription.
     pub async fn delete(mut self) -> Result<(), Error> {
         let request = api::DeleteSubscriptionRequest {
-            subscription: format!(
-                "projects/{0}/subscriptions/{1}",
-                self.client.project_name.as_str(),
-                self.name,
-            ),
+            subscription: self.name.clone(),
         };
         let request = self.client.construct_request(request).await?;
         self.client.subscriber.delete_subscription(request).await?;
@@ -109,11 +110,7 @@ impl Subscription {
 
     pub(crate) async fn pull(&mut self) -> Result<Vec<api::ReceivedMessage>, Error> {
         let request = api::PullRequest {
-            subscription: format!(
-                "projects/{0}/subscriptions/{1}",
-                self.client.project_name.as_str(),
-                self.name,
-            ),
+            subscription: self.name.clone(),
             return_immediately: false,
             max_messages: 5,
         };


### PR DESCRIPTION
This patch uses the fully qualified form, such as `projects/{project}/topics/{topic}`, as the name of topics/subscription. A public method `id()` is also exposed to get the user friendly unique identifiers.

See also: https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Topic
