### PR TITLE
Prepare for a `0.1.0` crates.io release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Implemented services
 
 | Service                                               | Feature name | Status          |
 | ----------------------------------------------------- | ------------ | --------------- |
-| [**Pub/Sub**](https://cloud.google.com/pubsub)        | `pubsub`     | **Done**        |
-| [**Datastore**](https://cloud.google.com/datastore)   | `datastore`  | **Done**        |
-| [**Cloud Storage**](https://cloud.google.com/storage) | `storage`    | **Done**        |
+| [**Pub/Sub**](https://cloud.google.com/pubsub)        | `pubsub`     | **Complete**    |
+| [**Datastore**](https://cloud.google.com/datastore)   | `datastore`  | **Complete**    |
+| [**Cloud Storage**](https://cloud.google.com/storage) | `storage`    | **Complete**    |
 | [**Cloud Vision**](https://cloud.google.com/vision)   | `vision`     | **In progress** |
 | [**Cloud Tasks**](https://cloud.google.com/tasks)     | `tasks`      | **In progress** |
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,46 @@
-google-cloud
-============
+google-cloud-rs
+===============
+
+![CI](https://github.com/google-apis-rs/google-cloud-rs/workflows/CI/badge.svg)
+![version](https://img.shields.io/crates/v/google-cloud)
+![docs](https://docs.rs/google-cloud/badge.svg)
+![license](https://img.shields.io/crates/l/google-cloud)
 
 Asynchronous Rust bindings for Google Cloud Platform gRPC APIs.
 
-Implementation status and roadmap
----------------------------------
+This library aims to create high-level and idiomatic bindings to Google Cloud Platform APIs and services.
 
-| Service           | Status          |
-| ----------------- | --------------- |
-| **Pub/Sub**       | Almost complete |
-| **Datastore**     | Almost complete |
-| **Cloud Vision**  | In progress     |
-| **Cloud Storage** | In progress     |
+Because of the breadth of the services offered by GCP and the desire to create idiomatic APIs for each of them, it currently only supports a handful of services.  
+Contributions for new service integrations are very welcome, since the entirety of GCP can be hard to cover by only a few maintainers.  
+
+If you are looking for lower-level bindings that offer more control and supports a lot more services (through automated code-generation), you can look into using [**`google-apis-rs/generator`**](https://github.com/google-apis-rs/generator).
+
+Implemented services
+--------------------
+
+| Service                                               | Feature name | Status          |
+| ----------------------------------------------------- | ------------ | --------------- |
+| [**Pub/Sub**](https://cloud.google.com/pubsub)        | `pubsub`     | **Done**        |
+| [**Datastore**](https://cloud.google.com/datastore)   | `datastore`  | **Done**        |
+| [**Cloud Storage**](https://cloud.google.com/storage) | `storage`    | **Done**        |
+| [**Cloud Vision**](https://cloud.google.com/vision)   | `vision`     | **In progress** |
+| [**Cloud Tasks**](https://cloud.google.com/tasks)     | `tasks`      | **In progress** |
+
+Examples
+--------
+
+You can see examples of how to use each of these integrations by looking at their [**different integration tests**](https://github.com/google-apis-rs/google-cloud-rs/tree/master/google-cloud/src/tests), which aims to model how these services are typically used.
+
+License
+-------
+
+Licensed under either of
+
+- Apache License, Version 2.0 (LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (LICENSE-MIT or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/google-cloud-derive/Cargo.toml
+++ b/google-cloud-derive/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
+[badges]
 maintenance = { status = "actively-developed" }
 
 [lib]

--- a/google-cloud-derive/Cargo.toml
+++ b/google-cloud-derive/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Derive macros for the `google-cloud` library"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
+
+maintenance = { status = "actively-developed" }
 
 [lib]
 proc-macro = true

--- a/google-cloud-derive/README.md
+++ b/google-cloud-derive/README.md
@@ -1,6 +1,11 @@
 google-cloud-derive
 ===================
 
+![CI](https://github.com/google-apis-rs/google-cloud-rs/workflows/CI/badge.svg)
+![version](https://img.shields.io/crates/v/google-cloud-derive)
+![docs](https://docs.rs/google-cloud-derive/badge.svg)
+![license](https://img.shields.io/crates/l/google-cloud-derive)
+
 Derive macros for the [**`google-cloud`**](https://crates.io/crates/google-cloud) crate.
 
 This crate is not intended to be used on its own.  

--- a/google-cloud-derive/README.md
+++ b/google-cloud-derive/README.md
@@ -1,4 +1,21 @@
 google-cloud-derive
 ===================
 
-Derive macros for the `google-cloud` crate.
+Derive macros for the [**`google-cloud`**](https://crates.io/crates/google-cloud) crate.
+
+This crate is not intended to be used on its own.  
+The features of this crate should be consumed by using the `derive` feature of the [**`google-cloud`**](https://github.com/google-apis-rs/google-cloud-rs/tree/master/google-cloud) crate.
+
+License
+-------
+
+Licensed under either of
+
+- Apache License, Version 2.0 (LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (LICENSE-MIT or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -6,6 +6,11 @@ authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"
 categories = ["web-programming", "network-programming", "asynchronous"]
 keywords = ["grpc", "futures", "async", "protobuf", "google", "cloud"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/google-apis-rs/google-cloud-rs"
+documentation = "https://docs.rs/google-cloud"
+
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 # Derive macros
@@ -45,3 +50,7 @@ datastore-derive = ["datastore", "google-cloud-derive"]
 vision = []
 storage = ["reqwest"]
 derive = ["datastore-derive"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/google-apis-rs/google-cloud-rs"
 documentation = "https://docs.rs/google-cloud"
 
+[badges]
 maintenance = { status = "actively-developed" }
 
 [dependencies]

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -1,14 +1,46 @@
 google-cloud
 ============
 
+![CI](https://github.com/google-apis-rs/google-cloud-rs/workflows/CI/badge.svg)
+![version](https://img.shields.io/crates/v/google-cloud)
+![docs](https://docs.rs/google-cloud/badge.svg)
+![license](https://img.shields.io/crates/l/google-cloud)
+
 Asynchronous Rust bindings for Google Cloud Platform gRPC APIs.
 
-Implementation status and roadmap
----------------------------------
+This library aims to create high-level and idiomatic bindings to Google Cloud Platform APIs and services.
 
-| Service           | Status          |
-| ----------------- | --------------- |
-| **Pub/Sub**       | Almost complete |
-| **Datastore**     | Almost complete |
-| **Cloud Vision**  | In progress     |
-| **Cloud Storage** | In progress     |
+Because of the breadth of the services offered by GCP and the desire to create idiomatic APIs for each of them, it currently only supports a handful of services.  
+Contributions for new service integrations are very welcome, since the entirety of GCP can be hard to cover by only a few maintainers.  
+
+If you are looking for lower-level bindings that offer more control and supports a lot more services (through automated code-generation), you can look into using [**`google-apis-rs/generator`**](https://github.com/google-apis-rs/generator).
+
+Implemented services
+--------------------
+
+| Service                                               | Feature name | Status          |
+| ----------------------------------------------------- | ------------ | --------------- |
+| [**Pub/Sub**](https://cloud.google.com/pubsub)        | `pubsub`     | **Done**        |
+| [**Datastore**](https://cloud.google.com/datastore)   | `datastore`  | **Done**        |
+| [**Cloud Storage**](https://cloud.google.com/storage) | `storage`    | **Done**        |
+| [**Cloud Vision**](https://cloud.google.com/vision)   | `vision`     | **In progress** |
+| [**Cloud Tasks**](https://cloud.google.com/tasks)     | `tasks`      | **In progress** |
+
+Examples
+--------
+
+You can see examples of how to use each of these integrations by looking at their [**different integration tests**](https://github.com/google-apis-rs/google-cloud-rs/tree/master/google-cloud/src/tests), which aims to model how these services are typically used.
+
+License
+-------
+
+Licensed under either of
+
+- Apache License, Version 2.0 (LICENSE-APACHE or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (LICENSE-MIT or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -20,9 +20,9 @@ Implemented services
 
 | Service                                               | Feature name | Status          |
 | ----------------------------------------------------- | ------------ | --------------- |
-| [**Pub/Sub**](https://cloud.google.com/pubsub)        | `pubsub`     | **Done**        |
-| [**Datastore**](https://cloud.google.com/datastore)   | `datastore`  | **Done**        |
-| [**Cloud Storage**](https://cloud.google.com/storage) | `storage`    | **Done**        |
+| [**Pub/Sub**](https://cloud.google.com/pubsub)        | `pubsub`     | **Complete**    |
+| [**Datastore**](https://cloud.google.com/datastore)   | `datastore`  | **Complete**    |
+| [**Cloud Storage**](https://cloud.google.com/storage) | `storage`    | **Complete**    |
 | [**Cloud Vision**](https://cloud.google.com/vision)   | `vision`     | **In progress** |
 | [**Cloud Tasks**](https://cloud.google.com/tasks)     | `tasks`      | **In progress** |
 

--- a/google-cloud/src/datastore/entity.rs
+++ b/google-cloud/src/datastore/entity.rs
@@ -50,7 +50,7 @@ impl Entity {
 
 /// Trait for converting a type to a Datastore entity (key + value).
 pub trait IntoEntity {
-    /// Attempts to construct a value of this type from the passed Datastore value.
+    /// Attempts to convert the type to a Datastore entity.
     /// Fails if the top level value is not a `Value::EntityValue`.
     fn into_entity(self) -> Result<Entity, ConvertError>;
 }

--- a/google-cloud/src/error.rs
+++ b/google-cloud/src/error.rs
@@ -49,7 +49,7 @@ pub enum ConvertError {
     },
 }
 
-/// The error type for value conversions.
+/// The error type for authentication-related errors.
 #[derive(Debug, Error)]
 pub enum AuthError {
     /// A JWT-related error.


### PR DESCRIPTION
This PR prepares the project for an initial `0.1.0` release on crates.io, by completing READMEs, adding metadata to `Cargo.toml` files.  
Even if we only have a few services implemented, it is already usable and can be of value to some other projects.  

My thought for how we would handle versioning up to `1.0.0` is that we would:

- bump the minor version (`0.1.0` -> `0.2.0`) if we make breaking changes to existing APIs or add a new service integration (pre-`1.0.0` versions are allowed to do breaking changes over a minor bump).  
- bump the patch version (`0.1.0` -> `0.1.1`) if we do changes that are only observable internally.
