### PR TITLE
Filled missing attributes in `Cargo.toml`

### DIFF
--- a/google-cloud-derive/Cargo.toml
+++ b/google-cloud-derive/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 description = "Derive macros for the `google-cloud` library"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"
+categories = ["web-programming", "network-programming", "asynchronous"]
+keywords = ["grpc", "futures", "async", "protobuf", "google", "cloud"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/google-apis-rs/google-cloud-rs"
+documentation = "https://docs.rs/google-cloud-derive"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This is to fix a little oversight that should have been done as part of **#28**, but just forgot.  
The `google-cloud-derive` crate manifest had missing attributes in its `Cargo.toml`, even though the one for `google-cloud` had them filled.  
