### PR TITLE
Add timeout support to pub/sub

### DIFF
--- a/google-cloud/src/pubsub/subscription.rs
+++ b/google-cloud/src/pubsub/subscription.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, VecDeque};
-use std::time::{Instant, Duration as StdDuration};
+use std::time::{Duration as StdDuration, Instant};
 
 use chrono::Duration;
 

--- a/google-cloud/src/pubsub/subscription.rs
+++ b/google-cloud/src/pubsub/subscription.rs
@@ -75,7 +75,7 @@ impl Subscription {
         self.receive_internal(None).await
     }
 
-    /// Receive the next message from the subscription, or until timeout.
+    /// Receive the next message from the subscription, or exits when timeout is reached.
     pub async fn receive_timeout(&mut self, timeout: StdDuration) -> Option<Message> {
         self.receive_internal(Some(timeout)).await
     }

--- a/google-cloud/src/pubsub/subscription.rs
+++ b/google-cloud/src/pubsub/subscription.rs
@@ -75,7 +75,7 @@ impl Subscription {
         self.receive_internal(None).await
     }
 
-    /// Receive the next message from the subscription, or exits when timeout is reached.
+    /// Receive the next message from the subscription, or exit when timeout is reached.
     pub async fn receive_timeout(&mut self, timeout: StdDuration) -> Option<Message> {
         self.receive_internal(Some(timeout)).await
     }


### PR DESCRIPTION
Hi!
This is just a small change to the pub/sub receive logic. As it is now, there's no way of politely stopping the subscription from pulling more messages, which is a bit of a pain when consuming from a stoppable thread.

I added a new `Subscription::receive_timeout()` method which accepts a timeout argument, and I extracted the common logic between the two receive methods.

Feel free to change the interface as you like :smile: 

Cheers!