### PR TITLE
feature(pubsub): Added ReceiveOptions for message pulling

### DIFF
--- a/google-cloud/src/pubsub/subscription.rs
+++ b/google-cloud/src/pubsub/subscription.rs
@@ -47,9 +47,12 @@ impl Default for SubscriptionConfig {
     }
 }
 
+/// Optional parameters for pull.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReceiveOptions {
+    /// return immediately if there are no messages in the subscription
     pub return_immediately: bool,
+    /// Number of messages to retrieve at once
     pub max_messages: i32,
 }
 
@@ -109,8 +112,10 @@ impl Subscription {
                 };
                 break Some(message);
             } else {
-                let response = self.pull(&opts).await;
-                if let Ok(messages) = response {
+                if let Ok(messages) = self.pull(&opts).await {
+                    if messages.is_empty() && opts.return_immediately {
+                        break None;
+                    }
                     self.buffer.extend(messages);
                 }
             }

--- a/google-cloud/src/tests/pubsub.rs
+++ b/google-cloud/src/tests/pubsub.rs
@@ -109,6 +109,15 @@ async fn pubsub_sends_and_receives_message_successfully() {
     assert_ok!(json::from_slice::<Message>(received.data()));
     println!("OK !");
 
+    let received = subscription
+        .receive_with_options(pubsub::ReceiveOptions {
+            return_immediately: true,
+            max_messages: 1,
+        })
+        .await;
+    assert_eq!(received.is_none(), true);
+    println!("OK !");
+
     //? Delete the subscription.
     print!("deleting subscription... ");
     io::stdout().flush().unwrap();


### PR DESCRIPTION
I want to handle SIGNAL and do graceful shutdown, so I want the `return_immediately` option.

How about it?