### PR TITLE
Update tokio to 1.x

### DIFF
--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -17,15 +17,15 @@ maintenance = { status = "actively-developed" }
 # Derive macros
 google-cloud-derive = { version = "=0.1.0", path = "../google-cloud-derive", optional = true }
 
-tonic = { version = "0.3.0", features = ["tls", "prost"] }
-tokio = { version = "0.2.18", features = ["macros", "fs"] }
+tonic = { version = "0.4.0", features = ["tls", "prost"] }
+tokio = { version = "1.2.0", features = ["macros", "fs"] }
 reqwest = { version = "0.10.4", optional = true, default_features = false, features = ["blocking", "json", "rustls-tls"] }
-hyper = { version = "0.13.7" }
-hyper-rustls = { version = "0.21.0" }
+hyper = "0.14.4"
+hyper-rustls = "0.22.1"
 futures = "0.3.4"
 
-prost = "0.6.1"
-prost-types = "0.6.1"
+prost = "0.7"
+prost-types = "0.7"
 
 http = "0.2.1"
 chrono = "0.4.11"

--- a/google-cloud/src/authorize/mod.rs
+++ b/google-cloud/src/authorize/mod.rs
@@ -67,7 +67,7 @@ impl TokenManager {
     pub(crate) fn new(creds: ApplicationCredentials, scopes: &[&str]) -> TokenManager {
         TokenManager {
             creds,
-            client: Client::builder().build::<_, hyper::Body>(HttpsConnector::new()),
+            client: Client::builder().build::<_, hyper::Body>(HttpsConnector::with_native_roots()),
             scopes: scopes.join(" "),
             current_token: None,
         }


### PR DESCRIPTION
This updates the dependencies of `google-cloud` so that it can be used with Tokio 1.x