### PR TITLE
fix(storage): Fixed error when bucket listing turns out to be empty

### DIFF
--- a/google-cloud/src/storage/api/bucket.rs
+++ b/google-cloud/src/storage/api/bucket.rs
@@ -10,6 +10,7 @@ use crate::storage::api::object_acl::ObjectAclResource;
 pub struct BucketResources {
     /// Value: "storage#buckets"
     pub kind: String,
+    #[serde(default)]
     pub items: Vec<BucketResource>,
 }
 


### PR DESCRIPTION
This PR fixes a bug that accidentally slipped under the radar where listing buckets would error out if no buckets are found.  

In that case, GCP turns out to directly omit the `items` field in its JSON response, instead of making it exist but be an empty list, so we fix this by defaulting to an empty `Vec` if not found. 

**Fixes #40.**