### PR TITLE
release(v0.2.0): Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+Changelog
+=========
+
+All notable changes to **`google-cloud-rs`** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+Unreleased
+----------
+
+### Added
+
+### Removed
+
+### Fixed
+
+### Changed
+
+v0.2.0 - 2021-03-24
+-------------------
+
+### Added
+
+- [pubsub] Added `Subscription::receive_with_options` (#33)
+
+### Removed
+
+### Fixed
+
+- [storage] Fixed error when bucket listing turns out to be empty (#42)
+- [pubsub] Changed default `max_messages` when pulling messages from `5` to `1` (#44)
+
+### Changed
+
+- Upgraded all dependencies (#35 and #41)
+
+v0.1.0 - 2020-08-23
+-------------------
+
+This is the initial release.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 google-cloud-rs
 ===============
 
-![CI](https://github.com/google-apis-rs/google-cloud-rs/workflows/CI/badge.svg)
-![version](https://img.shields.io/crates/v/google-cloud)
-![docs](https://docs.rs/google-cloud/badge.svg)
-![license](https://img.shields.io/crates/l/google-cloud)
+[![CI](https://github.com/google-apis-rs/google-cloud-rs/actions/workflows/ci.yaml/badge.svg)](https://github.com/google-apis-rs/google-cloud-rs/actions/workflows/ci.yaml)
+[![version](https://img.shields.io/crates/v/google-cloud)](https://crates.io/crates/google-cloud)
+[![docs](https://docs.rs/google-cloud/badge.svg)](https://docs.rs/google-cloud)
+[![license](https://img.shields.io/crates/l/google-cloud)](https://github.com/google-apis-rs/google-cloud-rs#license)
 
 Asynchronous Rust bindings for Google Cloud Platform gRPC APIs.
 

--- a/google-cloud-derive/Cargo.toml
+++ b/google-cloud-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-derive"
-version = "0.1.0"
+version = "0.2.0"
 description = "Derive macros for the `google-cloud` library"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"
@@ -28,3 +28,7 @@ darling = "0.10.2"
 [dev-dependencies]
 trybuild = "1.0.25"
 google-cloud = { path = "../google-cloud", features = ["derive"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/google-cloud-derive/README.md
+++ b/google-cloud-derive/README.md
@@ -1,10 +1,10 @@
 google-cloud-derive
 ===================
 
-![CI](https://github.com/google-apis-rs/google-cloud-rs/workflows/CI/badge.svg)
-![version](https://img.shields.io/crates/v/google-cloud-derive)
-![docs](https://docs.rs/google-cloud-derive/badge.svg)
-![license](https://img.shields.io/crates/l/google-cloud-derive)
+[![CI](https://github.com/google-apis-rs/google-cloud-rs/actions/workflows/ci.yaml/badge.svg)](https://github.com/google-apis-rs/google-cloud-rs/actions/workflows/ci.yaml)
+[![version](https://img.shields.io/crates/v/google-cloud)](https://crates.io/crates/google-cloud)
+[![docs](https://docs.rs/google-cloud/badge.svg)](https://docs.rs/google-cloud)
+[![license](https://img.shields.io/crates/l/google-cloud)](https://github.com/google-apis-rs/google-cloud-rs#license)
 
 Derive macros for the [**`google-cloud`**](https://crates.io/crates/google-cloud) crate.
 

--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "google-cloud"
+version = "0.2.0"
 description = "Asynchronous Rust bindings for Google Cloud Platform gRPC APIs"
-version = "0.1.0"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"
 categories = ["web-programming", "network-programming", "asynchronous"]

--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 # Derive macros
-google-cloud-derive = { version = "=0.1.0", path = "../google-cloud-derive", optional = true }
+google-cloud-derive = { version = "0.2.0", path = "../google-cloud-derive", optional = true }
 
 tonic = { version = "0.4.1", features = ["tls", "prost"] }
 tokio = { version = "1.4.0", features = ["macros", "fs"] }

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -1,10 +1,10 @@
 google-cloud
 ============
 
-![CI](https://github.com/google-apis-rs/google-cloud-rs/workflows/CI/badge.svg)
-![version](https://img.shields.io/crates/v/google-cloud)
-![docs](https://docs.rs/google-cloud/badge.svg)
-![license](https://img.shields.io/crates/l/google-cloud)
+[![CI](https://github.com/google-apis-rs/google-cloud-rs/actions/workflows/ci.yaml/badge.svg)](https://github.com/google-apis-rs/google-cloud-rs/actions/workflows/ci.yaml)
+[![version](https://img.shields.io/crates/v/google-cloud)](https://crates.io/crates/google-cloud)
+[![docs](https://docs.rs/google-cloud/badge.svg)](https://docs.rs/google-cloud)
+[![license](https://img.shields.io/crates/l/google-cloud)](https://github.com/google-apis-rs/google-cloud-rs#license)
 
 Asynchronous Rust bindings for Google Cloud Platform gRPC APIs.
 


### PR DESCRIPTION
This PR prepares to release v0.2.0 of **`google-cloud`** and **`google-cloud-derive`**.  

A `CHANGELOG.md` file has also been added to start recording the changes done to the library.
