### PR TITLE
fix(storage): Fixed user values not being percent-encoded

### DIFF
--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -37,6 +37,7 @@ jwt = { package = "jsonwebtoken", version = "7.2.0" }
 thiserror = "1.0.24"
 
 bytes = { version = "1.0.1", optional = true }
+percent-encoding = { version = "2.1.0", optional = true }
 
 [build-dependencies]
 tonic-build = "0.4.1"
@@ -49,7 +50,7 @@ pubsub = []
 datastore = []
 datastore-derive = ["datastore", "google-cloud-derive"]
 vision = []
-storage = ["reqwest"]
+storage = ["reqwest", "percent-encoding"]
 derive = ["datastore-derive"]
 
 [package.metadata.docs.rs]

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -1,3 +1,5 @@
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+
 use crate::storage::api::object::ObjectResource;
 use crate::storage::{Client, Error, Object};
 
@@ -30,7 +32,11 @@ impl Bucket {
     ) -> Result<Object, Error> {
         let client = &mut self.client;
         let inner = &client.client;
-        let uri = format!("{}/b/{}/o", Client::UPLOAD_ENDPOINT, self.name);
+        let uri = format!(
+            "{}/b/{}/o",
+            Client::UPLOAD_ENDPOINT,
+            utf8_percent_encode(&self.name, NON_ALPHANUMERIC),
+        );
 
         let data = data.into();
         let token = client.token_manager.lock().await.token().await?;
@@ -57,7 +63,12 @@ impl Bucket {
     pub async fn object(&mut self, name: &str) -> Result<Object, Error> {
         let client = &mut self.client;
         let inner = &client.client;
-        let uri = format!("{}/b/{}/o/{}", Client::ENDPOINT, self.name, name);
+        let uri = format!(
+            "{}/b/{}/o/{}",
+            Client::ENDPOINT,
+            utf8_percent_encode(&self.name, NON_ALPHANUMERIC),
+            utf8_percent_encode(name, NON_ALPHANUMERIC),
+        );
 
         let token = client.token_manager.lock().await.token().await?;
         let request = inner
@@ -79,7 +90,11 @@ impl Bucket {
     pub async fn delete(self) -> Result<(), Error> {
         let client = self.client;
         let inner = client.client;
-        let uri = format!("{}/b/{}", Client::ENDPOINT, self.name);
+        let uri = format!(
+            "{}/b/{}",
+            Client::ENDPOINT,
+            utf8_percent_encode(&self.name, NON_ALPHANUMERIC),
+        );
 
         let token = client.token_manager.lock().await.token().await?;
         let request = inner

--- a/google-cloud/src/storage/client.rs
+++ b/google-cloud/src/storage/client.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use std::sync::Arc;
 
 use json::json;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use tokio::sync::Mutex;
 
 use crate::authorize::{ApplicationCredentials, TokenManager};
@@ -71,7 +72,11 @@ impl Client {
     /// Get a handle to a specific bucket.
     pub async fn bucket(&mut self, name: &str) -> Result<Bucket, Error> {
         let inner = &self.client;
-        let uri = format!("{}/b/{}", Client::ENDPOINT, name);
+        let uri = format!(
+            "{}/b/{}",
+            Client::ENDPOINT,
+            utf8_percent_encode(name, NON_ALPHANUMERIC),
+        );
 
         let token = self.token_manager.lock().await.token().await?;
         let request = inner

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -1,4 +1,4 @@
-use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 use crate::storage::{Client, Error};
 

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -1,3 +1,5 @@
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+
 use crate::storage::{Client, Error};
 
 /// Represents a Cloud Storage bucket.
@@ -45,7 +47,12 @@ impl Object {
     pub async fn get(&mut self) -> Result<Vec<u8>, Error> {
         let client = &mut self.client;
         let inner = &client.client;
-        let uri = format!("{}/b/{}/o/{}", Client::ENDPOINT, self.bucket, self.name);
+        let uri = format!(
+            "{}/b/{}/o/{}",
+            Client::ENDPOINT,
+            utf8_percent_encode(&self.bucket, NON_ALPHANUMERIC),
+            utf8_percent_encode(&self.name, NON_ALPHANUMERIC),
+        );
 
         let token = client.token_manager.lock().await.token().await?;
         let request = inner
@@ -63,7 +70,12 @@ impl Object {
     pub async fn delete(self) -> Result<(), Error> {
         let client = self.client;
         let inner = client.client;
-        let uri = format!("{}/b/{}/o/{}", Client::ENDPOINT, self.bucket, self.name);
+        let uri = format!(
+            "{}/b/{}/o/{}",
+            Client::ENDPOINT,
+            utf8_percent_encode(&self.bucket, NON_ALPHANUMERIC),
+            utf8_percent_encode(&self.name, NON_ALPHANUMERIC),
+        );
 
         let token = client.token_manager.lock().await.token().await?;
         let request = inner


### PR DESCRIPTION
This PR fixes the issue that user-provided values like bucket names or object names were not percent-encoded as it should have been.  

**Fixes #32.** 