### PR TITLE
release(v0.2.1): Prepare v0.2.1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+/secrets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Unreleased
 
 ### Changed
 
+v0.2.1 - 2021-03-24
+-------------------
+
+### Added
+
+### Removed
+
+### Fixed
+
+- [storage] Fixed user values not being percent-encoded (#46)
+
+### Changed
+
 v0.2.0 - 2021-03-24
 -------------------
 

--- a/google-cloud-derive/Cargo.toml
+++ b/google-cloud-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-derive"
-version = "0.2.0"
+version = "0.2.1"
 description = "Derive macros for the `google-cloud` library"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"

--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud"
-version = "0.2.0"
+version = "0.2.1"
 description = "Asynchronous Rust bindings for Google Cloud Platform gRPC APIs"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"
@@ -15,7 +15,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 # Derive macros
-google-cloud-derive = { version = "0.2.0", path = "../google-cloud-derive", optional = true }
+google-cloud-derive = { version = "0.2.1", path = "../google-cloud-derive", optional = true }
 
 tonic = { version = "0.4.1", features = ["tls", "prost"] }
 tokio = { version = "1.4.0", features = ["macros", "fs"] }


### PR DESCRIPTION
This PR prepares to release v0.2.1 of **`google-cloud`** and **`google-cloud-derive`**.  
