### PR TITLE
Fall back to using metadata server in datastore Client constructor

### DIFF
--- a/google-cloud/src/authorize/mod.rs
+++ b/google-cloud/src/authorize/mod.rs
@@ -104,7 +104,6 @@ impl TokenManager {
 
     pub(crate) async fn from_metadata_server() -> TokenManager {
         let token_metadata = get_metadata().await.unwrap();
-        // println!("{:?}", token_metadata);
 
         // Hack: ApplicationCredentials are required by the type system
         // But given the behavior of the `token` method,
@@ -149,7 +148,6 @@ impl TokenManager {
                 // need to test
                 //
                 let token_metadata = get_metadata().await.unwrap();
-                println!("\n\nNEW\n\n{:?}\n\n", token_metadata);
                 let lifetime = chrono::Duration::seconds(token_metadata.expires_in - 1);
                 let token_value = TokenValue::Bearer(token_metadata.access_token);
                 let token_contents = token_value.to_string();

--- a/google-cloud/src/tests/datastore.rs
+++ b/google-cloud/src/tests/datastore.rs
@@ -16,7 +16,7 @@ macro_rules! assert_ok {
 
 async fn setup_client() -> Result<datastore::Client, datastore::Error> {
     // TODO env!("GCP_PROJECT")
-    datastore::Client::new("dl-datastore-staging".to_string()).await
+    datastore::Client::new("dl-datastore-stage".to_string()).await
 }
 
 #[tokio::test]

--- a/google-cloud/src/tests/datastore.rs
+++ b/google-cloud/src/tests/datastore.rs
@@ -15,8 +15,8 @@ macro_rules! assert_ok {
 }
 
 async fn setup_client() -> Result<datastore::Client, datastore::Error> {
-    let creds = super::load_creds();
-    datastore::Client::from_credentials(env!("GCP_TEST_PROJECT"), creds).await
+    // TODO env!("GCP_PROJECT")
+    datastore::Client::new("dl-datastore-staging".to_string()).await
 }
 
 #[tokio::test]

--- a/google-cloud/src/vision/api/google.cloud.vision.v1.rs
+++ b/google-cloud/src/vision/api/google.cloud.vision.v1.rs
@@ -1313,7 +1313,9 @@ pub mod text_annotation {
     }
     pub mod detected_break {
         /// Enum to denote the type of break found. New line, space etc.
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+        #[derive(
+            Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration,
+        )]
         #[repr(i32)]
         pub enum BreakType {
             /// Unknown break label type.
@@ -1780,7 +1782,9 @@ pub mod face_annotation {
         /// Left and right are defined from the vantage of the viewer of the image
         /// without considering mirror projections typical of photos. So, `LEFT_EYE`,
         /// typically, is the person's right eye.
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+        #[derive(
+            Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration,
+        )]
         #[repr(i32)]
         pub enum Type {
             /// Unknown face landmark detected. Should not be filled.


### PR DESCRIPTION
This PR modifies the `google-cloud-rs` client to support GCP workload identity / service accounts.

 In the absence of a GOOGLE_APPLICATION_CREDENTIALS env var referencing a service account json file, the client will now fall back to fetching the token [from the metadata server ](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#using_from_your_code). This should allow our ruster code to **automatically find the credentials at runtime** and is closer to the recommended behavior for client auth found in other languages.

Work in progress.