### PR TITLE
Bypass codegen for docs.rs build

### DIFF
--- a/google-cloud/build.rs
+++ b/google-cloud/build.rs
@@ -1,6 +1,13 @@
+use std::env;
 use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // The docs.rs build locks down write permissions and causes codegen to fail. Skip it since
+    // it's not really needed for rustdoc anyway.
+    if env::var("DOCS_RS").is_ok() {
+        return Ok(());
+    }
+
     let protos = [
         (["protos/google/pubsub/v1/pubsub.proto"], "src/pubsub/api"),
         (


### PR DESCRIPTION
The codegen performed in the build script returns an error in the
docs.rs build environment, as write permissions seem to be locked down.

This PR skips the codegen steps in the build script if the `DOCS_RS`
environment variable is set.

I didn't find a simple way in my Googling to bypass codegen for all rustdoc
builds, but it doesn't seem to pose a real problem outside docs.rs anyway.

 #### Testing

 I didn't want to pull the 10GB needed to run the Docker images that
 docs.rs uses. Instead, as a sanity check, I ran
 `cargo doc --all-features` with and without the `DOCS_RS` environment
 set and verified via strategically placed `panic!` macros that the
 build script was bypassed when the variable was set 😬

 #### References

 * <https://docs.rs/about/builds#detecting-docsrs>
 * docs.rs page: <https://docs.rs/crate/google-cloud/0.2.1>
 * Failed build: <https://docs.rs/crate/google-cloud/0.2.1/builds/366129>

Fixes #51