### PR TITLE
Datastore: Add support for unindexed string and blob types

### DIFF
--- a/google-cloud/src/datastore/client.rs
+++ b/google-cloud/src/datastore/client.rs
@@ -353,6 +353,7 @@ fn convert_entity(project_name: &str, entity: Entity) -> api::Entity {
 }
 
 fn convert_value(project_name: &str, value: Value) -> api::Value {
+    let mut exclude_from_indexes = false;
     let value_type = match value {
         Value::BooleanValue(val) => ValueType::BooleanValue(val),
         Value::IntegerValue(val) => ValueType::IntegerValue(val),
@@ -363,7 +364,15 @@ fn convert_value(project_name: &str, value: Value) -> api::Value {
         }),
         Value::KeyValue(key) => ValueType::KeyValue(convert_key(project_name, &key)),
         Value::StringValue(val) => ValueType::StringValue(val),
+        Value::UnindexedStringValue(val) => {
+            exclude_from_indexes = true;
+            ValueType::StringValue(val)
+        },
         Value::BlobValue(val) => ValueType::BlobValue(val),
+        Value::UnindexedBlobValue(val) => {
+            exclude_from_indexes = true;
+            ValueType::BlobValue(val)
+        },
         Value::GeoPointValue(latitude, longitude) => ValueType::GeoPointValue(api::LatLng {
             latitude,
             longitude,
@@ -386,7 +395,7 @@ fn convert_value(project_name: &str, value: Value) -> api::Value {
     };
     api::Value {
         meaning: 0,
-        exclude_from_indexes: false,
+        exclude_from_indexes,
         value_type: Some(value_type),
     }
 }

--- a/google-cloud/src/datastore/value.rs
+++ b/google-cloud/src/datastore/value.rs
@@ -29,8 +29,12 @@ pub enum Value {
     KeyValue(Key),
     /// A string value.
     StringValue(String),
+    /// An unindexed string value.
+    UnindexedStringValue(String),
     /// A blob value, just a block of bytes.
     BlobValue(Vec<u8>),
+    /// An unindexed blob value.
+    UnindexedBlobValue(Vec<u8>),
     /// An Earth geographic location value (with latitude and longitude).
     GeoPointValue(f64, f64),
     /// An entity value.
@@ -48,8 +52,8 @@ impl Value {
             Value::DoubleValue(_) => "double",
             Value::TimestampValue(_) => "timestamp",
             Value::KeyValue(_) => "key",
-            Value::StringValue(_) => "string",
-            Value::BlobValue(_) => "blob",
+            Value::StringValue(_) | Value::UnindexedStringValue(_) => "string",
+            Value::BlobValue(_) | Value::UnindexedBlobValue(_) => "blob",
             Value::GeoPointValue(_, _) => "geopoint",
             Value::EntityValue(_) => "entity",
             Value::ArrayValue(_) => "array",


### PR DESCRIPTION
Support `UnindexedString` and `UnindexedBlob` variant of the `Value` enum in datastore to allow using values larger than 1.5kb.  Ideally all dtypes in `Value` should support disabling indices, but these two are probably the most prominent use-cases.

closes #62 