### PR TITLE
Lists and metadata

### DIFF
--- a/google-cloud/Cargo.toml
+++ b/google-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud"
-version = "0.2.1"
+version = "0.3.0"
 description = "Asynchronous Rust bindings for Google Cloud Platform gRPC APIs"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 edition = "2018"

--- a/google-cloud/src/storage/api/object.rs
+++ b/google-cloud/src/storage/api/object.rs
@@ -6,6 +6,15 @@ use crate::storage::api::object_acl::ObjectAclResource;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ObjectResources {
+    /// Value: "storage#objects"
+    pub kind: String,
+    #[serde(default)]
+    pub items: Vec<ObjectResource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ObjectResource {
     // Value: "storage#object"
     pub kind: String,

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -83,6 +83,7 @@ impl Bucket {
             client.clone(),
             self.name.clone(),
             resource.name,
+            resource.metadata
         ))
     }
 

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -58,6 +58,7 @@ impl Bucket {
         Ok(Object::new(
             client.clone(),
             self.name.clone(),
+            resource.id,
             resource.name,
             resource.metadata.unwrap_or(HashMap::new()),
         ))
@@ -86,6 +87,7 @@ impl Bucket {
         Ok(Object::new(
             client.clone(),
             self.name.clone(),
+            resource.id,
             resource.name,
             resource.metadata.unwrap_or(HashMap::new()),
         ))
@@ -116,7 +118,7 @@ impl Bucket {
         let objects = resources
             .items
             .into_iter()
-            .map(|resource| Object::new(client.clone(), resource.name, resource.bucket, resource.metadata.unwrap_or(HashMap::new())))
+            .map(|resource| Object::new(client.clone(), resource.id, resource.name, resource.bucket, resource.metadata.unwrap_or(HashMap::new())))
             .collect();
 
         Ok(objects)

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -91,7 +91,7 @@ impl Bucket {
     }
 
     /// List objects stored in the bucket.
-    pub async fn list(&mut self, list_options: &HashMap<K, V>) -> Result<Object, Error> {
+    pub async fn list<V>(&mut self, list_options: &HashMap<String, V>) -> Result<Vec<Object>, Error> {
         let client = &mut self.client;
         let inner = &client.client;
         let uri = format!(

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -58,7 +58,7 @@ impl Bucket {
             client.clone(),
             self.name.clone(),
             resource.name,
-            resource.metadata,
+            resource.metadata.unwrap_or(HashMap::new()),
         ))
     }
 
@@ -86,7 +86,7 @@ impl Bucket {
             client.clone(),
             self.name.clone(),
             resource.name,
-            resource.metadata
+            resource.metadata.unwrap_or(HashMap::new()),
         ))
     }
 
@@ -115,7 +115,7 @@ impl Bucket {
         let objects = resources
             .items
             .into_iter()
-            .map(|resource| Object::new(client.clone(), resource.name, resource.bucket, resource.metadata))
+            .map(|resource| Object::new(client.clone(), resource.name, resource.bucket, resource.metadata.unwrap_or(HashMap::new()))
             .collect();
 
         Ok(objects)

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -91,7 +91,7 @@ impl Bucket {
     }
 
     /// List objects stored in the bucket.
-    pub async fn list(&mut self, list_options: &HashMap<String, T>) -> Result<Object, Error> {
+    pub async fn list(&mut self, list_options: &HashMap<K, V>) -> Result<Object, Error> {
         let client = &mut self.client;
         let inner = &client.client;
         let uri = format!(

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -115,7 +115,7 @@ impl Bucket {
         let objects = resources
             .items
             .into_iter()
-            .map(|resource| Object::new(client.clone(), resource.name, resource.bucket, resource.metadata.unwrap_or(HashMap::new()))
+            .map(|resource| Object::new(client.clone(), resource.name, resource.bucket, resource.metadata.unwrap_or(HashMap::new())))
             .collect();
 
         Ok(objects)

--- a/google-cloud/src/storage/bucket.rs
+++ b/google-cloud/src/storage/bucket.rs
@@ -3,6 +3,7 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use crate::storage::api::object::*;
 use crate::storage::{Client, Error, Object};
 
+use serde::Serialize;
 use std::collections::HashMap;
 
 /// Represents a Cloud Storage bucket.
@@ -91,7 +92,7 @@ impl Bucket {
     }
 
     /// List objects stored in the bucket.
-    pub async fn list<V>(&mut self, list_options: &HashMap<String, V>) -> Result<Vec<Object>, Error> {
+    pub async fn list<V: Serialize>(&mut self, list_options: &HashMap<String, V>) -> Result<Vec<Object>, Error> {
         let client = &mut self.client;
         let inner = &client.client;
         let uri = format!(

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -2,6 +2,8 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 use crate::storage::{Client, Error};
 
+use std::collections::HashMap;
+
 /// Represents a Cloud Storage bucket.
 #[derive(Clone)]
 pub struct Object {
@@ -16,7 +18,7 @@ impl Object {
         client: Client,
         bucket: impl Into<String>,
         name: impl Into<String>,
-        metadata: impl Into<HashMap<String:String>>,
+        metadata: impl Into<HashMap>,
     ) -> Object {
         Object {
             client,

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -18,13 +18,13 @@ impl Object {
         client: Client,
         bucket: impl Into<String>,
         name: impl Into<String>,
-        metadata: impl Into<HashMap<K, V>>,
+        metadata: HashMap<String, String>,
     ) -> Object {
         Object {
             client,
             name: name.into(),
             bucket: bucket.into(),
-            metadata: metadata.into(),
+            metadata: metadata,
         }
     }
 

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -40,7 +40,7 @@ impl Object {
 
     /// Get the object's metadata
     pub fn metadata(&self) -> &HashMap<String, String> {
-        self.metadata
+        &self.metadata
     }
 
     // /// Insert a new object into the bucket.

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 #[derive(Clone)]
 pub struct Object {
     pub(crate) client: Client,
+    pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) bucket: String,
     pub(crate) metadata: HashMap<String, String>,
@@ -17,15 +18,22 @@ impl Object {
     pub(crate) fn new(
         client: Client,
         bucket: impl Into<String>,
+        id: impl Into<String>,
         name: impl Into<String>,
         metadata: HashMap<String, String>,
     ) -> Object {
         Object {
             client,
+            id: id.into(),
             name: name.into(),
             bucket: bucket.into(),
             metadata: metadata,
         }
+    }
+
+    /// Get the object's id.
+    pub fn id(&self) -> &str {
+        self.id.as_str()
     }
 
     /// Get the object's name.

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -18,7 +18,7 @@ impl Object {
         client: Client,
         bucket: impl Into<String>,
         name: impl Into<String>,
-        metadata: impl Into<HashMap>,
+        metadata: impl Into<HashMap<K, V>>,
     ) -> Object {
         Object {
             client,

--- a/google-cloud/src/storage/object.rs
+++ b/google-cloud/src/storage/object.rs
@@ -8,6 +8,7 @@ pub struct Object {
     pub(crate) client: Client,
     pub(crate) name: String,
     pub(crate) bucket: String,
+    pub(crate) metadata: HashMap<String, String>,
 }
 
 impl Object {
@@ -15,11 +16,13 @@ impl Object {
         client: Client,
         bucket: impl Into<String>,
         name: impl Into<String>,
+        metadata: impl Into<HashMap<String:String>>,
     ) -> Object {
         Object {
             client,
             name: name.into(),
             bucket: bucket.into(),
+            metadata: metadata.into(),
         }
     }
 
@@ -31,6 +34,11 @@ impl Object {
     /// Get the object's bucket name.
     pub fn bucket(&self) -> &str {
         self.bucket.as_str()
+    }
+
+    /// Get the object's metadata
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        self.metadata
     }
 
     // /// Insert a new object into the bucket.


### PR DESCRIPTION
Adds support for getting the `id` and `metadata` of a GCS object. Also adds a `list` fn to the `bucket` struct, for listing out all the objects in a given bucket (with allowed `listOptions` to constrain the results).

Needed these for a project I'm working on, thought I'd raise the PR in case others find them useful as well :)