### PR TITLE
Deserialize Bucket retention policy from String to u64

### DIFF
--- a/google-cloud/src/deserializer/mod.rs
+++ b/google-cloud/src/deserializer/mod.rs
@@ -1,0 +1,39 @@
+use std::fmt;
+use serde::de::{self, Unexpected};
+use serde::Deserializer;
+
+pub fn deserialize_u64_or_string<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(DeserializeU64OrStringVisitor)
+}
+
+struct DeserializeU64OrStringVisitor;
+impl<'de> de::Visitor<'de> for DeserializeU64OrStringVisitor {
+    type Value = u64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an integer or a string")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+    {
+        Ok(v)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+    {
+        if let Ok(n) = v.parse::<u64>() {
+            Ok(n)
+        } else if v.is_empty() {
+            Ok(0)
+        } else {
+            Err(E::invalid_value(Unexpected::Str(v), &self))
+        }
+    }
+}

--- a/google-cloud/src/lib.rs
+++ b/google-cloud/src/lib.rs
@@ -8,6 +8,8 @@ extern crate google_cloud_derive;
 pub mod authorize;
 /// Error handling utilities.
 pub mod error;
+/// Complements serde deserializers.
+pub mod deserializer;
 
 /// Datastore bindings.
 #[cfg(feature = "datastore")]

--- a/google-cloud/src/storage/api/bucket.rs
+++ b/google-cloud/src/storage/api/bucket.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::storage::api::bucket_acl::BucketAclResource;
 use crate::storage::api::object_acl::ObjectAclResource;
+use crate::deserializer::deserialize_u64_or_string;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,9 +50,10 @@ pub struct BucketResource {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BucketRetentionPolicy {
-    pub pubretention_period: u64,
-    pub pubeffective_time: String,
-    pub pubis_locked: bool,
+    #[serde(deserialize_with = "deserialize_u64_or_string")]
+    pub retention_period: u64,
+    pub effective_time: String,
+    pub is_locked: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Currently when a bucket has retention policy enabled and we try to get the bucket it fails when deserializing it. 
Google Storage API is sending a String when a u64 is expected based on their [documentation](https://cloud.google.com/storage/docs/json_api/v1/buckets). 

This PR creates a specific deserializer for u64 when a String or 64 is being sent. 
I tried to find an existing crate which already solves this but couldn't find anything. 
However, as this is pretty simple to solve I thought I would just add the code in a new module and if in the future there's a well maintained crate to solve this kind of issues, then it will be pretty straightforward to refactor. 