### PR TITLE
feat(datastore): support unindexed values

### DIFF
--- a/google-cloud/src/datastore/client.rs
+++ b/google-cloud/src/datastore/client.rs
@@ -353,6 +353,7 @@ fn convert_entity(project_name: &str, entity: Entity) -> api::Entity {
 }
 
 fn convert_value(project_name: &str, value: Value) -> api::Value {
+    let mut exclude_from_indexes = false;
     let value_type = match value {
         Value::BooleanValue(val) => ValueType::BooleanValue(val),
         Value::IntegerValue(val) => ValueType::IntegerValue(val),
@@ -363,6 +364,10 @@ fn convert_value(project_name: &str, value: Value) -> api::Value {
         }),
         Value::KeyValue(key) => ValueType::KeyValue(convert_key(project_name, &key)),
         Value::StringValue(val) => ValueType::StringValue(val),
+        Value::IndexedValue(val, flag) => {
+            exclude_from_indexes = !flag;
+            convert_value(project_name, *val).value_type.unwrap() // cannot fail, return type is always Some(T)
+        }
         Value::BlobValue(val) => ValueType::BlobValue(val),
         Value::GeoPointValue(latitude, longitude) => ValueType::GeoPointValue(api::LatLng {
             latitude,
@@ -386,7 +391,7 @@ fn convert_value(project_name: &str, value: Value) -> api::Value {
     };
     api::Value {
         meaning: 0,
-        exclude_from_indexes: false,
+        exclude_from_indexes,
         value_type: Some(value_type),
     }
 }

--- a/google-cloud/src/datastore/value.rs
+++ b/google-cloud/src/datastore/value.rs
@@ -29,6 +29,8 @@ pub enum Value {
     KeyValue(Key),
     /// A string value.
     StringValue(String),
+    /// A value with an indexed/unindexed flag.
+    IndexedValue(Box<Value>, bool),
     /// A blob value, just a block of bytes.
     BlobValue(Vec<u8>),
     /// An Earth geographic location value (with latitude and longitude).
@@ -49,6 +51,7 @@ impl Value {
             Value::TimestampValue(_) => "timestamp",
             Value::KeyValue(_) => "key",
             Value::StringValue(_) => "string",
+            Value::IndexedValue(v, _) => v.type_name(),
             Value::BlobValue(_) => "blob",
             Value::GeoPointValue(_, _) => "geopoint",
             Value::EntityValue(_) => "entity",
@@ -72,6 +75,12 @@ pub trait FromValue: Sized {
 impl IntoValue for Value {
     fn into_value(self) -> Value {
         self
+    }
+}
+
+impl IntoValue for (Value, bool) {
+    fn into_value(self) -> Value {
+        Value::IndexedValue(Box::new(self.0), self.1)
     }
 }
 


### PR DESCRIPTION
`exclude_from_indexes` parameter is set to false as default. This PR makes it possible to specify the value of this parameter via using a tuple value as `IndexedValue`.
