### PR TITLE
feat(pubsub)!: support message attributes

### DIFF
--- a/google-cloud/src/pubsub/topic.rs
+++ b/google-cloud/src/pubsub/topic.rs
@@ -80,12 +80,16 @@ impl Topic {
     }
 
     /// Publish a message onto this topic.
-    pub async fn publish(&mut self, data: impl Into<Vec<u8>>) -> Result<(), Error> {
+    pub async fn publish(
+        &mut self,
+        data: impl Into<Vec<u8>>,
+        attributes: Option<HashMap<String, String>>,
+    ) -> Result<(), Error> {
         let request = api::PublishRequest {
             topic: self.name.clone(),
             messages: vec![api::PubsubMessage {
                 data: data.into(),
-                attributes: HashMap::new(),
+                attributes: attributes.unwrap_or_default(),
                 message_id: String::new(),
                 ordering_key: String::new(),
                 publish_time: None,

--- a/google-cloud/src/tests/pubsub.rs
+++ b/google-cloud/src/tests/pubsub.rs
@@ -88,7 +88,7 @@ async fn pubsub_sends_and_receives_message_successfully() {
     //? Publish that message onto the topic.
     print!("sending message... ");
     io::stdout().flush().unwrap();
-    assert_ok!(topic.publish(message).await);
+    assert_ok!(topic.publish(message, None).await);
     println!("OK !");
 
     //? Receive it back from the subscription.


### PR DESCRIPTION
This PR updates `google_cloud::pubsub::Topic::publish` function to support attaching attributes to the message.